### PR TITLE
 ### Commit Message:

### DIFF
--- a/exts/agv/data/control_center.py
+++ b/exts/agv/data/control_center.py
@@ -69,6 +69,7 @@ def compute(db: og.Database):
 
     # Publish location data
     if state.mqtt_client:
-        state.mqtt_client.publish("location", str(db.inputs.location))
+        # state.mqtt_client.publish("location", str(db.inputs.location))
+        state.mqtt_client.publish("location", "test")
 
     return True

--- a/exts/agv/data/orient.py
+++ b/exts/agv/data/orient.py
@@ -1,0 +1,13 @@
+def setup(db: og.Database):
+    state = db.internal_state
+
+def cleanup(db: og.Database):
+    pass
+
+def compute(db: og.Database):
+    state = db.internal_state
+    orient = db.inputs.orient
+    # orient is float[4] type data, print it with human readable text
+    print(f"orient: {orient}")
+
+    return True


### PR DESCRIPTION
Refactor action graph and add AGV properties graph

 • Rename create_action_graph to create_control_center_graph in ActionGraphManager.
 • Add a new method create_agv_properties_graph to read AGV's properties.
 • Comment out the original MQTT publish line in compute function.
 • Replace the original MQTT publish content with a test string.

 ### Changes:

 #### Modified Files:
 - `exts/agv/agv/extension.py`
 - `exts/agv/data/control_center.py`

 #### `exts/agv/agv/extension.py`:
 - Renamed method `create_action_graph` to `create_control_center_graph`.
 - Added new method `create_agv_properties_graph` to create a graph for reading AGV properties.
 - Updated `MyExtension` class to call `create_control_center_graph` and `create_agv_properties_graph` methods.

 #### `exts/agv/data/control_center.py`:
 - Commented out the original MQTT publish line.
 - Added a new line to publish test to the location topic.