### PR TITLE
feature: add-get-action-graph-state

### DIFF
--- a/exts/agv/data/control_center.py
+++ b/exts/agv/data/control_center.py
@@ -47,6 +47,11 @@ def cleanup(db: og.Database):
     if db.internal_state.mqtt_client:
         db.internal_state.mqtt_client.stop()
 
+def get_action_graph_script_node_state(db: og.Database, path_to_node: str):
+    node = og.get_node_by_path(path_to_node)
+    state = db.per_instance_internal_state(node)
+    return state
+
 def compute(db: og.Database):
     state = db.internal_state
 
@@ -67,17 +72,11 @@ def compute(db: og.Database):
     else:
         db.outputs.is_activate = False
 
-    # Publish location data
+    state_agv = get_action_graph_script_node_state(db, db.inputs.agv_properties_graph_prim_path)
+    print(f"AGV angular: {state_agv.angular})")
+
     if state.mqtt_client:
-        # state.mqtt_client.publish("location", str(db.inputs.location))
-        state.mqtt_client.publish("location", "test")
-
-
-    agv_properties_graph_prim_path = db.inputs.agv_properties_graph_prim_path
-    node = og.get_node_by_path(agv_properties_graph_prim_path)
-    state_agv = db.per_instance_internal_state(node)
-    print(state_agv.angular)
-    
+        state.mqtt_client.publish("angular", str(state_agv.angular))
 
 
     return True


### PR DESCRIPTION
### New Features 
- Added a new function `get_action_graph_script_node_state` to retrieve the state of a script node in the action graph.

 ### Improvements
 - Refactored the `compute` function to use the new `get_action_graph_script_node_state` function for cleaner code and better abstraction.

 ### Code Cleanup
 - Removed commented-out code that published location data to MQTT.
 - Removed redundant code for fetching the AGV state, now using the new function.

 ### Other Changes
 - Now publishing AGV angular state to MQTT instead of the previously hardcoded test message.